### PR TITLE
dictionary corrections

### DIFF
--- a/util/__init__.py
+++ b/util/__init__.py
@@ -36,26 +36,28 @@ class Util:
             # User wants to capture 1 of the 4 quadrants
             return {
                 # top left
-                '1': (window_size[0], window_size[1], window_size[2]/2, window_size[3]/2),
+                1: (window_size[0], window_size[1], window_size[2]/2, window_size[3]/2),
                 # top right
-                '2': (window_size[3]/2, window_size[1], window_size[2], window_size[3]/2),
+                2: (window_size[3]/2, window_size[1], window_size[2], window_size[3]/2),
                 # bottom left
-                '3': (window_size[0], window_size[3]/2, window_size[2]/2, window_size[3]),
+                # tighter region for hots health bar (0, y * .8, x * .25, y)
+                # 3: (window_size[0], window_size[3] * 0.8, window_size[2] * 0.25, window_size[3]),
+                3: (window_size[0], window_size[3]/2, window_size[2]/2, window_size[3]),
                 # bottom right
-                '4': (window_size[2]/2, window_size[3]/2, window_size[2], window_size[3]),
+                4: (window_size[2]/2, window_size[3]/2, window_size[2], window_size[3]),
             }.get(quadrant_number, window_size)
 
         if quadrant_capture_count == 2:
             return {
                 # top
                 # left top right bottom
-                '1': (window_size[0], window_size[1], window_size[2], window_size[3]/2),
+                1: (window_size[0], window_size[1], window_size[2], window_size[3]/2),
                 # bottom
-                '2': (window_size[0], window_size[3]/2, window_size[2], window_size[3]),
+                2: (window_size[0], window_size[3]/2, window_size[2], window_size[3]),
                 # bottom left
-                '3': (window_size[0], window_size[3]/2, window_size[2]/2, window_size[3]),
+                3: (window_size[0], window_size[3]/2, window_size[2]/2, window_size[3]),
                 # bottom right
-                '4': (window_size[2]/2, window_size[3]/2, window_size[2], window_size[3]),
+                4: (window_size[2]/2, window_size[3]/2, window_size[2], window_size[3]),
             }.get(quadrant_number, window_size)
 
         return window_size


### PR DESCRIPTION
Keys are numeric not strings there. Was trying this out with a Razer Chroma keyboard instead of a light (see commit in my fork, didn't want to introduce additional dependencies). Might eventually try tracking ability cooldown timers for that.

May want to make this more customizable in the settings yaml file, as in let people specify screen targets in terms of percentages. The vision part of this likes to sometimes identify the player health bar as the largest segment.

The alg also seems to get confused around 35% due to the numbers getting in the way. I didn't address that in this request but it may be better to track the maximum width bbox of the HP value and compute percentage filled by seeing where the furthest right contour is relative to max observed bbox width.